### PR TITLE
server: fix missing line terminator

### DIFF
--- a/invenio_sip2/server.py
+++ b/invenio_sip2/server.py
@@ -180,6 +180,7 @@ class SocketEventListener:
             self.response += 'AZ'
             self.response += self.calculate_checksum(self.response)
 
+        self.response += self.line_terminator
         message = bytes(self.response, self.message_encoding)
         return message
 


### PR DESCRIPTION
The line terminator is used to tell to client that all bytes are sent.

* Adds line terminator to response message.

Co-Authored-by: Lauren-D <laurent.dubois@itld-solutions.be>