### PR TITLE
logger: fix excessive logging

### DIFF
--- a/invenio_sip2/utils.py
+++ b/invenio_sip2/utils.py
@@ -57,7 +57,7 @@ def parse_circulation_date(date):
             return date.strftime(date_format)
         return date_string_to_utc(date).strftime(date_format)
     except Exception:
-        logger.error(f'parse circulation date error for: [{date}]')
+        logger.warning(f'parse circulation date error for: [{date}]')
         return date or ''
 
 


### PR DESCRIPTION
* Uses warning instead error to log parse circulation error.