### PR TITLE
fix(server): fix encoding problem and password exposure

### DIFF
--- a/invenio_sip2/server.py
+++ b/invenio_sip2/server.py
@@ -29,7 +29,11 @@ from invenio_sip2.errors import CommandNotFound
 from invenio_sip2.proxies import current_logger as logger
 from invenio_sip2.proxies import current_sip2
 from invenio_sip2.records import Client, Server
-from invenio_sip2.utils import verify_checksum, verify_sequence_number
+from invenio_sip2.utils import (
+    mask_sensitive_data,
+    verify_checksum,
+    verify_sequence_number,
+)
 
 
 class SocketServer:
@@ -183,11 +187,13 @@ class SocketEventListener:
                 ]
                 try:
                     self.request = Message(request=request_msg)
-                    request = (
-                        self.request.dumps()
-                        if logger.level == logging.DEBUG
-                        else request_msg
-                    )
+                    # mask credential fields so passwords never reach the logs
+                    masked_request_msg = mask_sensitive_data(request_msg)
+                    if logger.level == logging.DEBUG:
+                        request = self.request.dumps()
+                        request["_sip2"] = masked_request_msg
+                    else:
+                        request = masked_request_msg
 
                     logger.info(f"{log_prefix}: {request}")
 
@@ -195,7 +201,8 @@ class SocketEventListener:
                         self._recv_buffer += data
                     else:
                         logger.error(
-                            f"invalid checksum for: {request_msg}", exc_info=True
+                            f"invalid checksum for: {masked_request_msg}",
+                            exc_info=True,
                         )
                         # prepare request selcheck resend message
                         self.response = Message(

--- a/invenio_sip2/utils.py
+++ b/invenio_sip2/utils.py
@@ -140,16 +140,20 @@ def verify_checksum(message_str):
     # check minimum length of message
     # It should be 8 for request ACS resend and 11 for all other messaged
     minimum_len = 8 if message_str[:2] == "97" else 11
-    if len(message_str) >= minimum_len:
-        # sum all the byte values of each character in the message including
-        # the checksum identifier
-        value = sum(message.encode(acs_system.text_encoding))
-        # add the checksum hex value
-        value += checksum
+    if len(message_str) < minimum_len:
+        return False
 
-        # To validate the message the two's complement of calculated value
-        # should equal zero
-        return -value & 0xFFFF == 0
+    # SIP2 clients disagree on how to sum non-ASCII characters: some sum
+    # the encoded bytes, others sum the Unicode code points. Both agree on
+    # ASCII but diverge on multi-byte characters (e.g. "€"), so accept the
+    # message if either interpretation validates. The two's complement of the
+    # summed value plus the checksum should equal zero for a valid message.
+    for value in (
+        sum(message.encode(acs_system.text_encoding)),
+        sum(ord(char) for char in message),
+    ):
+        if -(value + checksum) & 0xFFFF == 0:
+            return True
     return False
 
 

--- a/invenio_sip2/utils.py
+++ b/invenio_sip2/utils.py
@@ -115,6 +115,28 @@ def get_circulation_status(status=None):
         return SelfcheckCirculationStatus.OTHER
 
 
+#: SIP2 variable field identifiers carrying credentials (terminal password,
+#: patron password and login password) that must be masked before logging.
+SENSITIVE_FIELD_IDS = ("AC", "AD", "CO")
+
+
+def mask_sensitive_data(message_str):
+    """Mask credential fields in a raw SIP2 message before logging.
+
+    SIP2 request messages embed passwords (fields "AC", "AD" and "CO") in
+    clear text. This replaces their value so logs and error reports never
+    expose them.
+
+    :param message_str: raw SIP2 string message
+    :returns: message with the value of sensitive fields replaced by "****"
+    """
+    parts = message_str.split("|")
+    for index, part in enumerate(parts):
+        if part[:2] in SENSITIVE_FIELD_IDS and len(part) > 2:
+            parts[index] = f"{part[:2]}****"
+    return "|".join(parts)
+
+
 def generate_checksum(message):
     """Generate and format checksum for SIP2 messages.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,6 +21,7 @@ from invenio_sip2.utils import (
     decode_char_to_bool,
     ensure_i18n_language,
     get_language_code,
+    mask_sensitive_data,
     parse_circulation_date,
     verify_checksum,
 )
@@ -87,3 +88,25 @@ def test_verify_checksum(app):
     assert verify_checksum(f"{body}{codepoint_checksum}")
     # a corrupted checksum is still rejected
     assert not verify_checksum(f"{body}0000")
+
+
+def test_mask_sensitive_data():
+    """Test masking of credential fields in raw SIP2 messages."""
+    # patron information request: patron password (AD) is masked
+    request = "6300120260720    051335          AO|AA123456|AC|AD$ecretPwd|AY3AZCC19"
+    masked = mask_sensitive_data(request)
+    assert "$ecretPwd" not in masked
+    assert "AD****" in masked
+    # non-sensitive fields (e.g. patron id) are left untouched
+    assert "AA123456" in masked
+    # empty credential field has no value to mask
+    assert "|AC|" in masked
+
+    # login request: login password (CO) is masked
+    login = "9300CNsip2ebook1|COs3cret|AY1AZF435"
+    masked_login = mask_sensitive_data(login)
+    assert "s3cret" not in masked_login
+    assert "CO****" in masked_login
+
+    # message without variable fields is returned unchanged
+    assert mask_sensitive_data("9900402.00AY2AZFCA3") == "9900402.00AY2AZFCA3"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,6 +22,7 @@ from invenio_sip2.utils import (
     ensure_i18n_language,
     get_language_code,
     parse_circulation_date,
+    verify_checksum,
 )
 
 
@@ -63,3 +64,26 @@ def test_get_language_code():
     assert get_language_code("FRENCH") == "002"
     # test unknown value
     assert get_language_code("inexisting_language") == "000"
+
+
+def test_verify_checksum(app):
+    """Test checksum verification for byte-summing and code-point clients."""
+    # SIP2 message body up to the "AZ" checksum identifier. It contains non-ASCII
+    # characters ("€", "é") whose UTF-8 byte sum differs from their code point, so
+    # byte-summing and code-point-summing clients build a different checksum for
+    # the very same message.
+    body = "6300120260720    051335          AO|AA123456|AC|AD$kajshkj#€ééé|AY3AZ"
+
+    def checksum(total):
+        return format(-total & 0xFFFF, "04X")
+
+    byte_checksum = checksum(sum(body.encode("UTF-8")))
+    codepoint_checksum = checksum(sum(ord(char) for char in body))
+    # the two interpretations genuinely diverge because of the non-ASCII chars
+    assert byte_checksum != codepoint_checksum
+
+    # both interpretations are accepted
+    assert verify_checksum(f"{body}{byte_checksum}")
+    assert verify_checksum(f"{body}{codepoint_checksum}")
+    # a corrupted checksum is still rejected
+    assert not verify_checksum(f"{body}0000")


### PR DESCRIPTION
## Commit 41662d7605430b394bf346ebdfb2440b6bb21264

fix(server): mask passwords in SIP2 request logs

SIP2 request messages embed the terminal, patron and login passwords
(fields "AC", "AD", "CO") in clear text. Both the request info log and
the "invalid checksum" error log emitted the raw message, exposing these
credentials in log files and error reporting tools (e.g. Sentry), where
generic password scrubbers do not match the raw wire format.

Add mask_sensitive_data() and redact those fields before logging, in the
error log, the info log and the debug "_sip2" field. Message.dumps() is
left untouched since its "_sip2" value is reused to resend messages.

Co-Authored-By: Pascal Repond <pascal.repond@rero.ch>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

## Commit 24ed00ab5d23d1c95581d39f1dd77a36fce4ae81

fix(server): accept SIP2 checksums summed over code points

Some SIP2 clients compute the message checksum by summing the
Unicode code points of each character instead of the encoded bytes.
Both approaches agree on ASCII but diverge on multi-byte characters
(e.g. "€"), so requests carrying non-ASCII fields were wrongly rejected
as having an invalid checksum, triggering a resend loop.

verify_checksum now accepts a message if either the encoded byte sum or
the code-point sum validates. This is backward compatible: for
single-byte and ASCII messages both sums are identical.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Co-Authored-By: Pascal Repond <pascal.repond@rero.ch>